### PR TITLE
[ruby] Fix compilation with newer bison. JB#57049

### DIFF
--- a/bootstrap/parse.h
+++ b/bootstrap/parse.h
@@ -49,6 +49,10 @@ extern int yydebug;
 # define YYTOKENTYPE
   enum yytokentype
   {
+    YYEMPTY = -2,
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+
     END_OF_INPUT = 0,
     keyword_class = 258,
     keyword_module = 259,


### PR DESCRIPTION
The latest update with commit d3b9dced7 regenerated the parse.h with bison 3.5.1 when the earlier was with 3.6.4. Some enum values were missed which made the compilation now fail with Bison 3.8.

Would be good to regenerate the bootstrap but as minimum effort fix now just manually adding them back. Otherwise the enum values and their numbers are the same.

@mlehtima 